### PR TITLE
fix: adjust remote form field validation for input_format logic so it does not override the field configuration

### DIFF
--- a/django_remote_forms/fields.py
+++ b/django_remote_forms/fields.py
@@ -122,7 +122,8 @@ class RemoteTimeField(RemoteField):
             # If initial value is datetime then convert it using first available input format
 
             if (isinstance(field_dict['initial'], (datetime.datetime, datetime.time, datetime.date))):
-                if not getattr(field_dict['input_formats'], 'len', None):
+                has_input_formats = len(field_dict.get('input_formats', [])) > 0
+                if not has_input_formats:
                     if isinstance(field_dict['initial'], datetime.datetime):
                         field_dict['input_formats'] = settings.DATETIME_INPUT_FORMATS
                     elif isinstance(field_dict['initial'], datetime.date):


### PR DESCRIPTION
We had an issue where the `input_formats` defined in the Django code were not being respected by the remote form lib. After a quick investigation, I found out the problem was in how the checks were done to decide whether to use the given field `input_formats` or override them using settings.